### PR TITLE
Add multi-file and network options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Examples of usecases for VoidRun include:
 - Debugging code in a controlled environment.
 - Executing code in a controlled environment.
 - Juging code in a controlled environment.
+- Running projects that require installing dependencies or network access.
+
+## New Features
+
+- **Multi-file execution**: upload several files at once.
+- **Dependency installation**: provide setup commands like `pip install`.
+- **Optional networking**: enable network access when needed for tests.
 
 ## Installation
 

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -2,8 +2,9 @@ import os
 from utils.fs import (
     create_sandbox_dir,
     save_file,
+    save_files,
     ensure_empty_stdin,
-    cleanup_dir
+    cleanup_dir,
 )
 from core.registry import get_executor_class
 from sandbox.firejail import FirejailSandbox
@@ -13,14 +14,22 @@ class ExecutionOrchestrator:
         self.timeout = timeout
         self.max_processes = max_processes
 
-    def execute(self, lang: str, code_file, stdin_file = None) -> dict:
+    def execute(
+        self,
+        lang: str,
+        code_files,
+        stdin_file=None,
+        setup_commands=None,
+        network_enabled: bool = False,
+    ) -> dict:
         sandbox_root = create_sandbox_dir()
         try:
-            code_filename = code_file.filename
-            code_path = os.path.join(sandbox_root, code_filename)
+            if not isinstance(code_files, list):
+                code_files = [code_files]
+
+            filenames = save_files(sandbox_root, code_files)
             stdin_path = os.path.join(sandbox_root, "stdin.txt")
 
-            save_file(code_path, code_file)
             if stdin_file:
                 save_file(stdin_path, stdin_file)
             else:
@@ -30,12 +39,14 @@ class ExecutionOrchestrator:
             sandbox = FirejailSandbox(
                 working_dir=sandbox_root,
                 timeout=self.timeout,
-                max_processes=self.max_processes
+                max_processes=self.max_processes,
+                network_enabled=network_enabled,
             )
             executor = ExecutorClass(
                 sandbox=sandbox,
-                code_file=code_filename,
-                stdin_file="stdin.txt"
+                code_files=filenames,
+                stdin_file="stdin.txt",
+                setup_commands=setup_commands,
             )
             return executor.run()
 

--- a/executors/c.py
+++ b/executors/c.py
@@ -2,5 +2,6 @@ from generics.base_executor import BaseExecutor
 
 class CExecutor(BaseExecutor):
     def get_execution_command(self) -> str:
-        # Compilation + run (all inside sandbox working dir)
-        return f"gcc {self.code_file} -o a.out && ./a.out"
+        # Compilation with potentially multiple files then execution
+        sources = " ".join(self.code_files)
+        return f"gcc {sources} -o a.out && ./a.out"

--- a/executors/python.py
+++ b/executors/python.py
@@ -2,4 +2,6 @@ from generics.base_executor import BaseExecutor
 
 class PythonExecutor(BaseExecutor):
     def get_execution_command(self) -> str:
-        return f"python3 {self.code_file}"
+        # first file is treated as the entry point
+        main_file = self.code_files[0]
+        return f"python3 {main_file}"

--- a/executors/ts_js.py
+++ b/executors/ts_js.py
@@ -2,6 +2,7 @@ from generics.base_executor import BaseExecutor
 
 class TSJSExecutor(BaseExecutor):
     def get_execution_command(self) -> str:
-        if self.code_file.endswith(".ts"):
-            return f"ts-node {self.code_file}"
-        return f"node {self.code_file}"
+        main_file = self.code_files[0]
+        if main_file.endswith(".ts"):
+            return f"ts-node {main_file}"
+        return f"node {main_file}"

--- a/generics/base_executor.py
+++ b/generics/base_executor.py
@@ -2,10 +2,18 @@ from generics.base_sandbox import BaseSandbox
 from abc import ABC, abstractmethod
 
 class BaseExecutor(ABC):
-    def __init__(self, sandbox: BaseSandbox, code_file: str, stdin_file: str):
+    def __init__(
+        self,
+        sandbox: BaseSandbox,
+        code_files: list[str],
+        stdin_file: str,
+        setup_commands: list[str] | None = None,
+    ):
         self.sandbox = sandbox
-        self.code_file = code_file
+        self.code_files = code_files
         self.stdin_file = stdin_file
+        # commands to be executed before running the main program
+        self.setup_commands = setup_commands or []
 
     @abstractmethod
     def get_execution_command(self) -> str:
@@ -16,9 +24,15 @@ class BaseExecutor(ABC):
         pass
 
     def run(self) -> dict:
-        """
-        Orchestrates code execution via the provided sandbox.
-        """
+        """Orchestrates optional setup and code execution via the sandbox."""
+        setup_results = []
+        for cmd in self.setup_commands:
+            result = self.sandbox.run(cmd, stdin_path=self.stdin_file)
+            setup_results.append({"command": cmd, **result})
+            if result.get("exit_code") != 0:
+                return {"setup_results": setup_results}
+
         command = self.get_execution_command()
-        return self.sandbox.run(command, stdin_path=self.stdin_file)
+        execution_result = self.sandbox.run(command, stdin_path=self.stdin_file)
+        return {"setup_results": setup_results, **execution_result}
 

--- a/generics/base_sandbox.py
+++ b/generics/base_sandbox.py
@@ -1,8 +1,10 @@
 from abc import ABC, abstractmethod
 
 class BaseSandbox(ABC):
-    def __init__(self, working_dir: str):
+    def __init__(self, working_dir: str, network_enabled: bool = False):
         self.working_dir = working_dir
+        # determines if the sandbox should allow network access
+        self.network_enabled = network_enabled
 
     @abstractmethod
     def run(self, command: str, stdin_path: str) -> dict:

--- a/sandbox/firejail.py
+++ b/sandbox/firejail.py
@@ -7,17 +7,19 @@ class FirejailSandbox(BaseSandbox):
         self,
         working_dir: str,
         timeout: int = 5,
-        max_processes: int = 10
+        max_processes: int = 10,
+        network_enabled: bool = False,
     ):
-        super().__init__(working_dir)
+        super().__init__(working_dir, network_enabled)
         self.timeout = timeout
         self.max_processes = max_processes
 
     def run(self, command: str, stdin_path: str) -> dict:
         # Wrap the user command with ulimit + firejail + timeout
+        net_option = "" if self.network_enabled else "--net=none"
         sandbox_cmd = (
             f"ulimit -u {self.max_processes}; "
-            f"firejail --quiet --net=none --private={self.working_dir} "
+            f"firejail --quiet {net_option} --private={self.working_dir} "
             f"timeout {self.timeout} {command}"
         )
 

--- a/services/http_service.py
+++ b/services/http_service.py
@@ -1,6 +1,19 @@
 from core.orchestrator import ExecutionOrchestrator
 
-def run_via_http(lang: str, code_file, stdin_file = None) -> dict:
+
+def run_via_http(
+    lang: str,
+    code_files,
+    stdin_file=None,
+    setup_commands=None,
+    network_enabled: bool = False,
+) -> dict:
     orchestrator = ExecutionOrchestrator()
-    return orchestrator.execute(lang, code_file, stdin_file)
+    return orchestrator.execute(
+        lang,
+        code_files,
+        stdin_file=stdin_file,
+        setup_commands=setup_commands,
+        network_enabled=network_enabled,
+    )
 

--- a/services/judge_expected_service.py
+++ b/services/judge_expected_service.py
@@ -1,6 +1,20 @@
 from services.run_script import run_code_and_capture
 
-def judge_expected(lang: str, code_file, stdin_file, expected_output: str) -> dict:
-    result = run_code_and_capture(lang, code_file, stdin_file)
+
+def judge_expected(
+    lang: str,
+    code_files,
+    stdin_file,
+    expected_output: str,
+    setup_commands=None,
+    network_enabled: bool = False,
+) -> dict:
+    result = run_code_and_capture(
+        lang,
+        code_files,
+        stdin_file,
+        setup_commands=setup_commands,
+        network_enabled=network_enabled,
+    )
     result["correct"] = result["stdout"].strip() == expected_output.strip()
     return result

--- a/services/judge_scripted_service.py
+++ b/services/judge_scripted_service.py
@@ -1,7 +1,21 @@
 from services.run_script import run_code_and_capture
 
-def judge_with_script(lang: str, code_file, stdin_file, judge_script_path: str) -> dict:
-    result = run_code_and_capture(lang, code_file, stdin_file)
+
+def judge_with_script(
+    lang: str,
+    code_files,
+    stdin_file,
+    judge_script_path: str,
+    setup_commands=None,
+    network_enabled: bool = False,
+) -> dict:
+    result = run_code_and_capture(
+        lang,
+        code_files,
+        stdin_file,
+        setup_commands=setup_commands,
+        network_enabled=network_enabled,
+    )
     try:
         import subprocess
         judge_result = subprocess.run(

--- a/services/run_script.py
+++ b/services/run_script.py
@@ -1,5 +1,18 @@
 from core.orchestrator import ExecutionOrchestrator
 
-def run_code_and_capture(lang: str, code_file, stdin_file = None) -> dict:
+
+def run_code_and_capture(
+    lang: str,
+    code_files,
+    stdin_file=None,
+    setup_commands=None,
+    network_enabled: bool = False,
+) -> dict:
     orchestrator = ExecutionOrchestrator()
-    return orchestrator.execute(lang, code_file, stdin_file)
+    return orchestrator.execute(
+        lang,
+        code_files,
+        stdin_file=stdin_file,
+        setup_commands=setup_commands,
+        network_enabled=network_enabled,
+    )

--- a/services/websocket_service.py
+++ b/services/websocket_service.py
@@ -1,4 +1,11 @@
-def enqueue_websocket_execution(connection, lang: str, code_file, stdin_file = None):
+def enqueue_websocket_execution(
+    connection,
+    lang: str,
+    code_files,
+    stdin_file=None,
+    setup_commands=None,
+    network_enabled: bool = False,
+):
     # Placeholder for websocket-based queuing
     # connection is assumed to be an open WebSocket connection
     connection.send_text("[VoidRun] WebSocket queuing not yet implemented.")

--- a/utils/fs.py
+++ b/utils/fs.py
@@ -19,6 +19,15 @@ def save_file(dest_path: str, file_obj) -> None:
     with open(dest_path, "wb") as f:
         f.write(file_obj.file.read())
 
+def save_files(dest_dir: str, files) -> list[str]:
+    """Saves multiple UploadFile objects to dest_dir and returns their names."""
+    filenames = []
+    for file_obj in files:
+        dest_path = os.path.join(dest_dir, file_obj.filename)
+        save_file(dest_path, file_obj)
+        filenames.append(file_obj.filename)
+    return filenames
+
 def ensure_empty_stdin(path: str) -> None:
     """
     Creates an empty stdin.txt file if no stdin provided.


### PR DESCRIPTION
## Summary
- support multi-file execution and dependency install in BaseExecutor
- update BaseSandbox and FirejailSandbox to allow network access
- extend orchestrator and services with new parameters
- update FastAPI endpoints for multi-file and setup commands
- document new features in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68451e7be2ac833288d8e542ac05f384